### PR TITLE
Implement QuizTab component; Refactor Quizzes Screen to use new TopQuizzesNavigationBar component

### DIFF
--- a/frontend/app/(tabs)/quizzes/[id].tsx
+++ b/frontend/app/(tabs)/quizzes/[id].tsx
@@ -1,8 +1,7 @@
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { useState } from 'react';
 import { useLocalSearchParams } from 'expo-router';
 import QuizIntroduction from '@/components/quiz/QuizIntroduction';
-import TopTabs from '@/components/quiz/TopTabs';
 import Header from '@/components/Header';
 
 export default function QuizScreen() {
@@ -18,8 +17,8 @@ export default function QuizScreen() {
   return (
     <View className="flex-1">
       <Header />
-      <TopTabs />
       <QuizIntroduction isVisible={isVisible} onClose={handleOnClose} />
+      <Text className="text-2xl">Quiz Functionality Coming Soon...</Text>
     </View>
   );
 }

--- a/frontend/app/(tabs)/quizzes/index.tsx
+++ b/frontend/app/(tabs)/quizzes/index.tsx
@@ -1,56 +1,12 @@
-import { ScrollView, View, Text } from 'react-native';
-import { useEffect } from 'react';
+import { View } from 'react-native';
 import Header from '@/components/Header';
-import TestKnowledgeSection from '@/components/quizzes/TestKnowledgeSection';
-import QuizOfTheDaySection from '@/components/quizzes/QuizOfTheDaySection';
-import { useQuizzes } from '@/hooks/quizzes/useQuizzes';
-import { useFeaturedQuiz } from '@/hooks/quizzes/useFeaturedQuiz';
+import TopQuizzesNavigationBar from '@/components/quizzes/TopQuizzesNavigationBar';
 
 export default function QuizzesScreen() {
-  const { getQuizzes, quizzes, loadingQuizzes, quizzesErrorMsg } = useQuizzes();
-  const {
-    getFeaturedQuiz,
-    featuredQuiz,
-    loadingFeaturedQuiz,
-    featuredFeaturedErrorMsg,
-  } = useFeaturedQuiz();
-
-  useEffect(() => {
-    getQuizzes(5);
-    getFeaturedQuiz();
-  }, []); // Fetch quizzes and featured quiz data
-
   return (
-    <ScrollView>
+    <View className='flex-1'>
       <Header />
-      <TestKnowledgeSection
-        quizzes={quizzes?.['quiz-preview']}
-        loading={loadingQuizzes}
-        error={quizzesErrorMsg}
-      />
-      <View className="mt-5">
-        {loadingFeaturedQuiz ? (
-          <View>
-            <Text>Loading...</Text>
-          </View>
-        ) : featuredFeaturedErrorMsg ? (
-          <View>
-            <Text>{featuredFeaturedErrorMsg} Contact Support Team</Text>
-          </View>
-        ) : featuredQuiz ? (
-          <QuizOfTheDaySection
-            id={featuredQuiz.id}
-            level={featuredQuiz.level}
-            title={featuredQuiz.title}
-            description={featuredQuiz.description}
-            amount-of-questions={featuredQuiz['amount-of-questions']}
-          />
-        ) : (
-          <View>
-            <Text>No featured quiz available</Text>
-          </View>
-        )}
-      </View>
-    </ScrollView>
+      <TopQuizzesNavigationBar />
+    </View>
   );
 }

--- a/frontend/components/BottomNavigationBar.tsx
+++ b/frontend/components/BottomNavigationBar.tsx
@@ -69,8 +69,6 @@ const BottomNavigationBar = () => {
       {/* <Tabs.Screen name="articles/[id]" options={{ href: null }} /> Add once the Article Page is developing */}
       <Tabs.Screen name="settings" options={{ href: null }} />
       <Tabs.Screen name="aqi-details" options={{ href: null }} />
-      <Tabs.Screen name="leaderboard" options={{ href: null }} />
-      <Tabs.Screen name="badges" options={{ href: null }} />
     </Tabs>
   );
 };

--- a/frontend/components/badges/BadgesTab.tsx
+++ b/frontend/components/badges/BadgesTab.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, Text } from 'react-native';
 import Badge from '@/components/badges/Badge';
 
-export default function BadgesScreen() {
+export default function BadgesTab() {
   return (
     <ScrollView className="p-10">
       <Text className="text-2xl">Badges Page</Text>

--- a/frontend/components/leaderboard/LeaderboardTab.tsx
+++ b/frontend/components/leaderboard/LeaderboardTab.tsx
@@ -6,7 +6,7 @@ import {
   leaderboardUsersStatic,
 } from '@/constants/StaticData';
 
-export default function LeaderboardScreen() {
+export default function LeaderboardTab() {
   return (
     <ScrollView>
       <View className="p-3">

--- a/frontend/components/quiz/QuizTab.tsx
+++ b/frontend/components/quiz/QuizTab.tsx
@@ -1,9 +1,54 @@
-import { View, Text } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
+import { useEffect } from 'react';
+import TestKnowledgeSection from '@/components/quizzes/TestKnowledgeSection';
+import QuizOfTheDaySection from '@/components/quizzes/QuizOfTheDaySection';
+import { useQuizzes } from '@/hooks/quizzes/useQuizzes';
+import { useFeaturedQuiz } from '@/hooks/quizzes/useFeaturedQuiz';
 
 export default function QuizTab() {
+  const { getQuizzes, quizzes, loadingQuizzes, quizzesErrorMsg } = useQuizzes();
+  const {
+    getFeaturedQuiz,
+    featuredQuiz,
+    loadingFeaturedQuiz,
+    featuredFeaturedErrorMsg,
+  } = useFeaturedQuiz();
+
+  useEffect(() => {
+    getQuizzes(5);
+    getFeaturedQuiz();
+  }, []); // Fetch quizzes and featured quiz data
+
   return (
-    <View>
-      <Text>Quiz Tab</Text>
-    </View>
+    <ScrollView>
+      <TestKnowledgeSection
+        quizzes={quizzes?.['quiz-preview']}
+        loading={loadingQuizzes}
+        error={quizzesErrorMsg}
+      />
+      <View className="mt-5">
+        {loadingFeaturedQuiz ? (
+          <View>
+            <Text>Loading...</Text>
+          </View>
+        ) : featuredFeaturedErrorMsg ? (
+          <View>
+            <Text>{featuredFeaturedErrorMsg} Contact Support Team</Text>
+          </View>
+        ) : featuredQuiz ? (
+          <QuizOfTheDaySection
+            id={featuredQuiz.id}
+            level={featuredQuiz.level}
+            title={featuredQuiz.title}
+            description={featuredQuiz.description}
+            amount-of-questions={featuredQuiz['amount-of-questions']}
+          />
+        ) : (
+          <View>
+            <Text>No featured quiz available</Text>
+          </View>
+        )}
+      </View>
+    </ScrollView>
   );
 }

--- a/frontend/components/quiz/QuizTab.tsx
+++ b/frontend/components/quiz/QuizTab.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function QuizTab() {
+  return (
+    <View>
+      <Text>Quiz Tab</Text>
+    </View>
+  );
+}

--- a/frontend/components/quiz/TopTabs.tsx
+++ b/frontend/components/quiz/TopTabs.tsx
@@ -1,6 +1,6 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
-import LeaderboardScreen from '@/app/(tabs)/leaderboard';
-import BadgesScreen from '@/app/(tabs)/badges';
+import LeaderboardScreen from '@/components/leaderboard/LeaderboardTab';
+import BadgesScreen from '@/components/badges/BadgesTab';
 
 const TopTab = createMaterialTopTabNavigator();
 

--- a/frontend/components/quiz/TopTabs.tsx
+++ b/frontend/components/quiz/TopTabs.tsx
@@ -1,13 +1,15 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
-import LeaderboardScreen from '@/components/leaderboard/LeaderboardTab';
+import LeaderboardTab from '@/components/leaderboard/LeaderboardTab';
 import BadgesScreen from '@/components/badges/BadgesTab';
+import QuizTab from './QuizTab';
 
 const TopTab = createMaterialTopTabNavigator();
 
 export default function TopTabs() {
   return (
-    <TopTab.Navigator initialRouteName='Leaderboard'>
-      <TopTab.Screen name="Leaderboard" component={LeaderboardScreen} />
+    <TopTab.Navigator initialRouteName='Quiz'>
+      <TopTab.Screen name="Quiz" component={QuizTab} />
+      <TopTab.Screen name="Leaderboard" component={LeaderboardTab} />
       <TopTab.Screen name="Badges" component={BadgesScreen} />
     </TopTab.Navigator>
   );

--- a/frontend/components/quizzes/TopQuizzesNavigationBar.tsx
+++ b/frontend/components/quizzes/TopQuizzesNavigationBar.tsx
@@ -1,11 +1,11 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import LeaderboardTab from '@/components/leaderboard/LeaderboardTab';
 import BadgesScreen from '@/components/badges/BadgesTab';
-import QuizTab from './QuizTab';
+import QuizTab from '../quiz/QuizTab';
 
 const TopTab = createMaterialTopTabNavigator();
 
-export default function TopTabs() {
+export default function TopQuizzesNavigationBar() {
   return (
     <TopTab.Navigator initialRouteName='Quiz'>
       <TopTab.Screen name="Quiz" component={QuizTab} />


### PR DESCRIPTION
# Overview

This PR introduces significant updates to the quiz navigation, component organization, and general functionality for better clarity, maintainability, and user interaction.

## Key Changes

- Rename `BadgesScreen` and `LeaderboardScreen` components to `BadgesTab` and `LeaderboardTab` for consistency.
- Add `QuizTab` component for managing quiz-related views, including quiz fetching and loading states.
- Update `TopTabs` to include `QuizTab` and rename components for better clarity.
- Remove `Leaderboard` and `Badges` tabs from the `BottomNavigationBar` to streamline the navigation.
- Refactor `TopTabs` to `TopQuizzesNavigationBar` and move it to the quizzes folder for better component organization.
- Update `QuizScreen` to include placeholder text and remove unused `TopTabs` component.
- Refactor quizzes index page to use the newly implemented `TopQuizzesNavigationBar` component and remove old code.
- Fix the **Blur Effect** issue in the Quiz Screen by adding a `Header` component